### PR TITLE
Child resources is of type array.

### DIFF
--- a/Functions/New-ARMresource.ps1
+++ b/Functions/New-ARMresource.ps1
@@ -69,7 +69,7 @@ Param(
     [hashtable]
     $Properties
     ,
-    [hashtable]
+    [array]
     $Resources
 )
 DynamicParam


### PR DESCRIPTION
In order to add child resources to a resource, the property type must be an array and not hashtable.