### PR TITLE
Added script analyzer settings and fixed violations.

### DIFF
--- a/Functions/Add-ARMparameter.ps1
+++ b/Functions/Add-ARMparameter.ps1
@@ -1,7 +1,6 @@
 #Requires -Version 5.0
-function Add-ARMparameter
-{
-<#
+function Add-ArmParameter {
+    <#
 .SYNOPSIS
     Add an ARM parameter to an ARM template.
 
@@ -37,58 +36,50 @@ function Add-ARMparameter
     Twitter: @ToreGroneng
 #>
     
-[cmdletbinding()]
-Param(
-    [Parameter(Mandatory, ValueFromPipeline)]
-    [PSTypeName('ARMparameter')]
-    $InputObject
-    ,
-    [PSTypeName('ARMtemplate')]
-    $Template
-    ,
-    [switch]
-    $PassThru
-)
-
-Begin
-{
-    $f = $MyInvocation.InvocationName    
-    Write-Verbose -Message "$f - START"
-}
-
-Process
-{
-    Write-Verbose -Message "$f -  Processing"
-
-    if (-not $Template)
-    {
-        Write-Verbose -Message "$f -  Using module level template"
-        $Template = $script:Template
-    }
-    
-    if ($Template)
-    {
-        Write-Verbose -Message "$f -  Have a template"
-        foreach ($prop in $InputObject.PSobject.Properties)
-        {
-            $value = $prop.Value
-            Write-Verbose -Message "$f -  Processing property $($prop.Name)"            
-            $Template.parameters | Add-Member -MemberType NoteProperty -Name $prop.Name -Value $value
-        }    
-    }
-    else 
-    {
-        Write-Verbose -Message "$f -  Template not found"        
-    }
-
-    if ($PassThru.IsPresent)
-    {
+    [cmdletbinding()]
+    Param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [PSTypeName('ARMparameter')]
         $InputObject
-    }
-}
+        ,
+        [PSTypeName('ARMtemplate')]
+        $Template
+        ,
+        [switch]
+        $PassThru
+    )
 
-End
-{
-    Write-Verbose -Message "$f - End"
-}
+    Begin {
+        $f = $MyInvocation.InvocationName    
+        Write-Verbose -Message "$f - START"
+    }
+
+    Process {
+        Write-Verbose -Message "$f -  Processing"
+
+        if (-not $Template) {
+            Write-Verbose -Message "$f -  Using module level template"
+            $Template = $script:Template
+        }
+    
+        if ($Template) {
+            Write-Verbose -Message "$f -  Have a template"
+            foreach ($prop in $InputObject.PSobject.Properties) {
+                $value = $prop.Value
+                Write-Verbose -Message "$f -  Processing property $($prop.Name)"            
+                $Template.parameters | Add-Member -MemberType NoteProperty -Name $prop.Name -Value $value
+            }    
+        }
+        else {
+            Write-Verbose -Message "$f -  Template not found"        
+        }
+
+        if ($PassThru.IsPresent) {
+            $InputObject
+        }
+    }
+
+    End {
+        Write-Verbose -Message "$f - End"
+    }
 }

--- a/Functions/Add-ARMresource.ps1
+++ b/Functions/Add-ARMresource.ps1
@@ -1,7 +1,6 @@
 #Requires -Version 5.0
-function Add-ARMresource
-{
-<#
+function Add-ArmResource {
+    <#
 .SYNOPSIS
     Add an ARM resource to an ARM template.
 
@@ -42,46 +41,40 @@ function Add-ARMresource
     Website: www.firstpoint.no
     Twitter: @ToreGroneng
 #>
-[cmdletbinding()]
-Param(
-    [Parameter(Mandatory, ValueFromPipeline)]
-    [PSTypeName('ARMresource')]
-    $InputObject
-    ,    
-    [PSTypeName('ARMtemplate')]
-    $Template
-    ,
-    [switch]
-    $PassThru
-)
-
-Begin
-{
-    $f = $MyInvocation.InvocationName    
-    Write-Verbose -Message "$f - START"
-}
-
-Process
-{
-    if (-not $Template)
-    {
-        Write-Verbose -Message "$f -  Using module level template"
-        $Template = $script:Template
-    }
-
-    if ($Template)
-    {
-        $Template.resources += $InputObject
-    }
-
-    if ($PassThru.IsPresent)
-    {
+    [cmdletbinding()]
+    Param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [PSTypeName('ARMresource')]
         $InputObject
-    }
-}
+        ,    
+        [PSTypeName('ARMtemplate')]
+        $Template
+        ,
+        [switch]
+        $PassThru
+    )
 
-End
-{
-    Write-Verbose -Message "$f - End"
-}
+    Begin {
+        $f = $MyInvocation.InvocationName    
+        Write-Verbose -Message "$f - START"
+    }
+
+    Process {
+        if (-not $Template) {
+            Write-Verbose -Message "$f -  Using module level template"
+            $Template = $script:Template
+        }
+
+        if ($Template) {
+            $Template.resources += $InputObject
+        }
+
+        if ($PassThru.IsPresent) {
+            $InputObject
+        }
+    }
+
+    End {
+        Write-Verbose -Message "$f - End"
+    }
 }

--- a/Functions/Add-ARMvariable.ps1
+++ b/Functions/Add-ARMvariable.ps1
@@ -1,7 +1,6 @@
 #Requires -Version 5.0
-function Add-ARMvariable
-{
-<#
+function Add-ArmVariable {
+    <#
 .SYNOPSIS
     Add an ARM variable to an ARM template.
 
@@ -36,54 +35,47 @@ function Add-ARMvariable
     Website: www.firstpoint.no
     Twitter: @ToreGroneng
 #>
-[cmdletbinding()]
-Param(
-    [Parameter(Mandatory, ValueFromPipeline)]
-    [PSTypeName('ARMvariable')]
-    $InputObject
-    ,
-    [PSTypeName('ARMtemplate')]
-    $Template
-    ,
-    [switch]
-    $PassThru
-)
-Begin
-{
-    $f = $MyInvocation.InvocationName    
-    Write-Verbose -Message "$f - START"
-}
-
-Process
-{
-    Write-Verbose -Message "$f -  Processing"
-
-    if (-not $Template)
-    {
-        Write-Verbose -Message "$f -  Using module level template"
-        $Template = $script:Template
-    }
-    
-    if ($Template)
-    {
-        Write-Verbose -Message "$f -  Have a template"
-        foreach ($prop in $InputObject.PSobject.Properties)
-        {
-            $value = $prop.Value
-            Write-Verbose -Message "$f -  Processing property $($prop.Name)"            
-            $Template.variables | Add-Member -MemberType NoteProperty -Name $prop.Name -Value $value
-        } 
-    }
-
-    if ($PassThru.IsPresent)
-    {
+    [cmdletbinding()]
+    Param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [PSTypeName('ARMvariable')]
         $InputObject
+        ,
+        [PSTypeName('ARMtemplate')]
+        $Template
+        ,
+        [switch]
+        $PassThru
+    )
+    Begin {
+        $f = $MyInvocation.InvocationName    
+        Write-Verbose -Message "$f - START"
     }
-}
 
-End
-{
-    Write-Verbose -Message "$f - End"
-}
+    Process {
+        Write-Verbose -Message "$f -  Processing"
+
+        if (-not $Template) {
+            Write-Verbose -Message "$f -  Using module level template"
+            $Template = $script:Template
+        }
+    
+        if ($Template) {
+            Write-Verbose -Message "$f -  Have a template"
+            foreach ($prop in $InputObject.PSobject.Properties) {
+                $value = $prop.Value
+                Write-Verbose -Message "$f -  Processing property $($prop.Name)"            
+                $Template.variables | Add-Member -MemberType NoteProperty -Name $prop.Name -Value $value
+            } 
+        }
+
+        if ($PassThru.IsPresent) {
+            $InputObject
+        }
+    }
+
+    End {
+        Write-Verbose -Message "$f - End"
+    }
 
 }

--- a/Functions/ConvertTo-Hash.ps1
+++ b/Functions/ConvertTo-Hash.ps1
@@ -1,7 +1,6 @@
 #Requires -Version 5.0
-function ConvertTo-Hash
-{
-<#
+function ConvertTo-Hash {
+    <#
 .SYNOPSIS
     Converts a PScustomobject to a hashtable
 
@@ -32,71 +31,60 @@ function ConvertTo-Hash
     Website: www.firstpoint.no
     Twitter: @ToreGroneng
 #>
-[cmdletbinding()]
-Param(
-    [Parameter(ValueFromPipeline)]
-    [PSCustomObject]$InputObject
-)
-Begin{
-    $f = $MyInvocation.InvocationName
-    Write-Verbose -Message "$f - START"
-}
-Process
-{   
-    Write-Verbose -Message "$F -  processing $($inputobject.GetType().Name)" 
-    if ($InputObject -is [array])
-    {
-        Write-Verbose -Message "Is array object"
-        foreach ($item in $value)
-        {            
-            $item | ConvertTo-Hash
-        }        
+    [cmdletbinding()]
+    Param(
+        [Parameter(ValueFromPipeline)]
+        [PSCustomObject]$InputObject
+    )
+    Begin {
+        $f = $MyInvocation.InvocationName
+        Write-Verbose -Message "$f - START"
     }
+    Process {   
+        Write-Verbose -Message "$F -  processing $($inputobject.GetType().Name)" 
+        if ($InputObject -is [array]) {
+            Write-Verbose -Message "Is array object"
+            foreach ($item in $value) {            
+                $item | ConvertTo-Hash
+            }        
+        }
 
-    if ($InputObject -is [hashtable] -or $InputObject -is [System.Collections.Specialized.OrderedDictionary])
-    {
-        return $InputObject
-    }
+        if ($InputObject -is [hashtable] -or $InputObject -is [System.Collections.Specialized.OrderedDictionary]) {
+            return $InputObject
+        }
 
-    $hash = [ordered]@{}
+        $hash = [ordered]@{}
 
-    if ($InputObject -is [System.Management.Automation.PSCustomObject])
-    {
-        Write-Verbose -Message "$f -  Processing [pscustomobject]"
+        if ($InputObject -is [System.Management.Automation.PSCustomObject]) {
+            Write-Verbose -Message "$f -  Processing [pscustomobject]"
 
-        foreach ($prop in $InputObject.psobject.Properties)
-        {
-            $name = $prop.Name
-            $value = $prop.Value
-            Write-Verbose -Message "$f - Property [$name]"
+            foreach ($prop in $InputObject.psobject.Properties) {
+                $name = $prop.Name
+                $value = $prop.Value
+                Write-Verbose -Message "$f - Property [$name]"
             
 
-            if ($value -is [System.Management.Automation.PSCustomObject])
-            {
-                Write-Verbose -Message "$f -  Value is PScustomobject"
-                $value = $value | ConvertTo-Hash                    
-            }
-
-            if ($value -is [array])
-            {
-                Write-Verbose -Message "Is array value"
-                $hashValue = @()
-                if ($value[0] -is [hashtable] -or $value[0] -is [System.Collections.Specialized.OrderedDictionary] -or $value[0] -is [PSCustomObject])
-                {
-                    foreach ($item in $value)
-                    {            
-                        $hashValue += ($item | ConvertTo-Hash)
-                    }
+                if ($value -is [System.Management.Automation.PSCustomObject]) {
+                    Write-Verbose -Message "$f -  Value is PScustomobject"
+                    $value = $value | ConvertTo-Hash                    
                 }
-                else 
-                {
-                    $hashValue = $value
-                }                               
-                $value = $hashValue
+
+                if ($value -is [array]) {
+                    Write-Verbose -Message "Is array value"
+                    $hashValue = @()
+                    if ($value[0] -is [hashtable] -or $value[0] -is [System.Collections.Specialized.OrderedDictionary] -or $value[0] -is [PSCustomObject]) {
+                        foreach ($item in $value) {            
+                            $hashValue += ($item | ConvertTo-Hash)
+                        }
+                    }
+                    else {
+                        $hashValue = $value
+                    }                               
+                    $value = $hashValue
+                }
+                $hash.Add($name, $value)
             }
-            $hash.Add($name,$value)
         }
+        $hash
     }
-    $hash
-}
 }

--- a/Functions/Get-ARMparameter.ps1
+++ b/Functions/Get-ARMparameter.ps1
@@ -1,7 +1,6 @@
 #Requires -Version 5.0
-function Get-ARMparameter
-{
-<#
+function Get-ArmParameter {
+    <#
 .SYNOPSIS
     Get all parameters or a specific one by name.
  
@@ -31,67 +30,58 @@ function Get-ARMparameter
     Website: www.firstpoint.no
     Twitter: @ToreGroneng
 #>
-[CmdletBinding()]
-[OutputType('PSCustomObject')]
-Param ()
+    [CmdletBinding()]
+    [OutputType('PSCustomObject')]
+    Param ()
 
-DynamicParam
-{
-    $Dictionary = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
+    DynamicParam {
+        $Dictionary = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
 
-    $NewDynParam = @{
-        Name = "Name"            
-        Mandatory = $false
-        ValueFromPipelineByPropertyName = $true
-        ValueFromPipeline = $false
-        DPDictionary = $Dictionary            
+        $NewDynParam = @{
+            Name = "Name"            
+            Mandatory = $false
+            ValueFromPipelineByPropertyName = $true
+            ValueFromPipeline = $false
+            DPDictionary = $Dictionary            
+        }
+
+        $allParameters = $script:Template.parameters.PSobject.Properties.Name
+
+        if ($allParameters) {
+            $null = $NewDynParam.Add("ValidateSet", $allParameters)
+        }
+        else {
+            $null = $NewDynParam.Add("ValidateSet", @("-"))
+        }
+
+        New-DynamicParam @NewDynParam
+        $Dictionary
     }
 
-    $allParameters = $script:Template.parameters.PSobject.Properties.Name
-
-    if ($allParameters)
-    {
-        $null = $NewDynParam.Add("ValidateSet",$allParameters)
-    }
-    else
-    {
-        $null = $NewDynParam.Add("ValidateSet",@("-"))
+    BEGIN {
+        $f = $MyInvocation.InvocationName
+        Write-Verbose -Message "$f - START"
     }
 
-    New-DynamicParam @NewDynParam
-    $Dictionary
-}
-
-BEGIN 
-{
-    $f = $MyInvocation.InvocationName
-    Write-Verbose -Message "$f - START"
-}
-
-PROCESS 
-{       
-    $Name = $PSBoundParameters.Name
+    PROCESS {       
+        $Name = $PSBoundParameters.Name
     
-    if (-not $PSBoundParameters.ContainsKey("Template"))
-    {
-        $Template = $script:Template
-    }
+        if (-not $PSBoundParameters.ContainsKey("Template")) {
+            $Template = $script:Template
+        }
 
-    if ($Name)
-    {
-        Write-Verbose -Message "$f -  Finding parameter with name [$Name]"
+        if ($Name) {
+            Write-Verbose -Message "$f -  Finding parameter with name [$Name]"
         
-        $Template.parameters | Select-Object -Property $Name
+            $Template.parameters | Select-Object -Property $Name
+        }
+        else {
+            Write-Verbose -Message "$f -  Returning all parameters"            
+            $Template.parameters
+        }
     }
-    else 
-    {
-        Write-Verbose -Message "$f -  Returning all parameters"            
-        $Template.parameters
-    }
-}
 
-END 
-{
-    Write-Verbose -Message "$f - START"
-}
+    END {
+        Write-Verbose -Message "$f - START"
+    }
 }

--- a/Functions/Get-ARMparameterScript.ps1
+++ b/Functions/Get-ARMparameterScript.ps1
@@ -1,7 +1,6 @@
 #Requires -Version 5.0
-function Get-ARMparameterScript
-{
-<#
+function Get-ArmParameterScript {
+    <#
 .SYNOPSIS
     Get the Powershell script that will recreate the parameteres in the ARM template
 
@@ -26,49 +25,44 @@ function Get-ARMparameterScript
     Twitter: @ToreGroneng
 #>
     
-[cmdletbinding()]
-Param(
-    [Parameter(ValueFromPipeline)]
-    [PSCustomObject]
-    $Parameters
-)
+    [cmdletbinding()]
+    Param(
+        [Parameter(ValueFromPipeline)]
+        [PSCustomObject]
+        $Parameters
+    )
 
-Begin
-{
-    $f = $MyInvocation.InvocationName
-    Write-Verbose -Message "$f - START"    
-}
-
-Process
-{    
-    Write-Verbose -Message "$f -  Converting to hashtable"
-    
-    $allParams = $Parameters | ConvertTo-Hash
-
-    foreach ($key in $allParams.Keys)
-    {
-        Write-Verbose -Message "$f -  Processing key [$key]"
-        
-        $cmdline = '$parameter = '
-        $paramHash =  @{
-            Name = $key
-        }
-
-        foreach ($subkey in $allParams.$key.Keys)
-        {
-            $paramHash.Add($subkey,$allParams.$key.$subkey)
-        }
-        
-        $params = $paramHash | Out-HashString
-            
-        $cmdline = "$cmdline $params" + [environment]::NewLine
-        "$cmdline" + "New-ARMparameter @parameter | Add-ARMparameter" + [environment]::NewLine + [environment]::NewLine
+    Begin {
+        $f = $MyInvocation.InvocationName
+        Write-Verbose -Message "$f - START"    
     }
-}
 
-End
-{
-    Write-Verbose -Message "$f - END"
+    Process {    
+        Write-Verbose -Message "$f -  Converting to hashtable"
     
-}
+        $allParams = $Parameters | ConvertTo-Hash
+
+        foreach ($key in $allParams.Keys) {
+            Write-Verbose -Message "$f -  Processing key [$key]"
+        
+            $cmdline = '$parameter = '
+            $paramHash = @{
+                Name = $key
+            }
+
+            foreach ($subkey in $allParams.$key.Keys) {
+                $paramHash.Add($subkey, $allParams.$key.$subkey)
+            }
+        
+            $params = $paramHash | Out-HashString
+            
+            $cmdline = "$cmdline $params" + [environment]::NewLine
+            "$cmdline" + "New-ARMparameter @parameter | Add-ARMparameter" + [environment]::NewLine + [environment]::NewLine
+        }
+    }
+
+    End {
+        Write-Verbose -Message "$f - END"
+    
+    }
 }

--- a/Functions/Get-ARMresourceList.ps1
+++ b/Functions/Get-ARMresourceList.ps1
@@ -1,7 +1,6 @@
 #Requires -Version 5.0
-function Get-ARMresourceList
-{
-<#
+function Get-ArmResourceList {
+    <#
 .SYNOPSIS
     Get a list of resource providers in Azure
 
@@ -29,11 +28,16 @@ function Get-ARMresourceList
     Website: www.firstpoint.no
     Twitter: @ToreGroneng
 #>
-[cmdletbinding()]
-Param(
-    [string]
-    $ResourceFile = (Split-Path -Path $PSScriptRoot -Parent | Join-Path -childpath Data | join-path -childpath allResources.json)
-)
+    [cmdletbinding()]
+    Param(
+        [string]
+        $ResourceFile
+    )
+    # Seems like using the 'PSScriptRoot' automatic variable in a parameter default value can cause some problems.
+    # Safer to initialize the parameter this way if it's undefined.
+    if ([string]::IsNullOrEmpty($ResourceFile)) {
+        $ResourceFile = Split-Path -Path $PSScriptRoot -Parent | Join-Path -childpath Data | join-path -childpath allResources.json
+    }
 
     $f = $MyInvocation.InvocationName
     Write-Verbose -Message "$f - START"
@@ -46,11 +50,9 @@ Param(
 
     $list = New-Object -TypeName System.Collections.Generic.List[string]
 
-    foreach ($Resource in $allResources)
-    {
+    foreach ($Resource in $allResources) {
         $providerNameSpace = $Resource.ProviderNamespace
-        foreach ($type in $Resource.ResourceTypes)
-        {            
+        foreach ($type in $Resource.ResourceTypes) {            
             $fullNameSpace = "$providerNameSpace/$($type.ResourceTypeName)"            
             $list.Add($fullNameSpace)
         }

--- a/Functions/Get-ARMresourceScript.ps1
+++ b/Functions/Get-ARMresourceScript.ps1
@@ -1,7 +1,6 @@
 #Requires -Version 5.0
-function Get-ARMresourceScript
-{
-<#
+function Get-ArmResourceScript {
+    <#
 .SYNOPSIS
     Get the Powershell script that will recreate the resources in the ARM template
 
@@ -25,40 +24,35 @@ function Get-ARMresourceScript
     Website: www.firstpoint.no
     Twitter: @ToreGroneng
 #>
-[cmdletbinding()]
-Param(
-    [Parameter(ValueFromPipeline)]
-    [PSCustomObject]
-    $Resources
-)
+    [cmdletbinding()]
+    Param(
+        [Parameter(ValueFromPipeline)]
+        [PSCustomObject]
+        $Resources
+    )
 
-Begin
-{
-    $f = $MyInvocation.InvocationName
-    Write-Verbose -Message "$f - START"
+    Begin {
+        $f = $MyInvocation.InvocationName
+        Write-Verbose -Message "$f - START"
 
-    $cmd = Get-Command -Name New-ARMresource
-    $cmdParams = $cmd.Parameters.Keys
-}
-
-Process
-{
-    foreach ($resource in $Resources)
-    {
-        $hash = $resource | ConvertTo-Hash
-        $cmdline = '$resource = '
-
-        foreach ($key in $hash.Keys)
-        {
-            if ($key -notin $cmdParams)
-            {
-                Write-Warning -Message "Parameter [$key] not found in $($cmd.Name)"
-            }
-        }
-
-        $params = $hash | Out-HashString
-        $cmdline = "$cmdline$params" + [environment]::NewLine
-        "$cmdline" + "New-ARMresource @resource | Add-ARMresource" + [environment]::NewLine + [environment]::NewLine
+        $cmd = Get-Command -Name New-ARMresource
+        $cmdParams = $cmd.Parameters.Keys
     }
-}
+
+    Process {
+        foreach ($resource in $Resources) {
+            $hash = $resource | ConvertTo-Hash
+            $cmdline = '$resource = '
+
+            foreach ($key in $hash.Keys) {
+                if ($key -notin $cmdParams) {
+                    Write-Warning -Message "Parameter [$key] not found in $($cmd.Name)"
+                }
+            }
+
+            $params = $hash | Out-HashString
+            $cmdline = "$cmdline$params" + [environment]::NewLine
+            "$cmdline" + "New-ARMresource @resource | Add-ARMresource" + [environment]::NewLine + [environment]::NewLine
+        }
+    }
 }

--- a/Functions/Get-ARMtemplate.ps1
+++ b/Functions/Get-ARMtemplate.ps1
@@ -1,7 +1,6 @@
 #Requires -Version 5.0
-function Get-ARMtemplate
-{
-<#
+function Get-ArmTemplate {
+    <#
 .SYNOPSIS
     Get the ARM template defined at the module level
 
@@ -28,41 +27,36 @@ function Get-ARMtemplate
     Website: www.firstpoint.no
     Twitter: @ToreGroneng
 #>
-[cmdletbinding(
-    DefaultParameterSetName='foo'
-)]
-Param(
-    [Parameter(ParameterSetName='JSON')]
-    [switch]$AsJSON
-    ,
-    [Parameter(ParameterSetName='HASH')]
-    [switch]$AsHashTableString
-)
+    [cmdletbinding(
+        DefaultParameterSetName = 'foo'
+    )]
+    Param(
+        [Parameter(ParameterSetName = 'JSON')]
+        [switch]$AsJSON
+        ,
+        [Parameter(ParameterSetName = 'HASH')]
+        [switch]$AsHashTableString
+    )
 
-Begin
-{
-    $f = $MyInvocation.InvocationName
-    Write-Verbose -Message "$f - START"    
-}
-
-Process
-{
-    if ($AsJSON.IsPresent -eq $false -and $AsHashTableString.IsPresent -eq $false)
-    {
-        $Script:Template
+    Begin {
+        $f = $MyInvocation.InvocationName
+        Write-Verbose -Message "$f - START"    
     }
 
-    if ($AsJSON.IsPresent)
-    {
-        $json = $Script:Template | ConvertTo-Json -Depth 99
-        $json = $json.replace("\u0027","'")#'
-        $json
-    }
+    Process {
+        if ($AsJSON.IsPresent -eq $false -and $AsHashTableString.IsPresent -eq $false) {
+            $Script:Template
+        }
 
-    if ($AsHashTableString.IsPresent)
-    {
-        $Script:Template | ConvertTo-Hash | Out-HashString
-    }    
-}
+        if ($AsJSON.IsPresent) {
+            $json = $Script:Template | ConvertTo-Json -Depth 99
+            $json = $json.replace("\u0027", "'")#'
+            $json
+        }
+
+        if ($AsHashTableString.IsPresent) {
+            $Script:Template | ConvertTo-Hash | Out-HashString
+        }    
+    }
    
 }

--- a/Functions/Get-ARMtemplateScript.ps1
+++ b/Functions/Get-ARMtemplateScript.ps1
@@ -1,7 +1,6 @@
 #Requires -Version 5.0
-function Get-ARMtemplateScript
-{
-<#
+function Get-ArmTemplateScript {
+    <#
 .SYNOPSIS
     Get the Powershell script that will recreate the ARM template
 
@@ -25,47 +24,42 @@ function Get-ARMtemplateScript
     Website: www.firstpoint.no
     Twitter: @ToreGroneng
 #>    
-[cmdletbinding()]
-Param(
-    [Parameter(ValueFromPipeline)]
-    [pscustomobject]$Template
-)
+    [cmdletbinding()]
+    Param(
+        [Parameter(ValueFromPipeline)]
+        [pscustomobject]$Template
+    )
 
-Begin
-{
-    $f = $MyInvocation.InvocationName
-    Write-Verbose -Message "$f - START"
-    $stringBuilder = New-Object -TypeName System.Text.StringBuilder
-}
-
-Process
-{    
-    if ($Template)
-    {        
-        $null = $stringBuilder.AppendLine('New-ARMtemplate')
-        $null = $stringBuilder.AppendLine()
-
-        Write-Verbose -Message "$f -  Processing variables"
-        [string]$vars = $Template.variables | Get-ARMvariableScript
-        $null = $stringBuilder.AppendLine($vars)
-
-        Write-Verbose -Message "$f -  Processing parameters"
-        [string]$params = $Template.parameters | Get-ARMparameterScript
-        $null = $stringBuilder.AppendLine($params)
-
-        Write-Verbose -Message "$f -  Processing resources"        
-        foreach ($resource in $Template.resources)
-        {
-            [string]$res = $resource | Get-ARMresourceScript
-            $null = $stringBuilder.AppendLine($res)
-        }       
+    Begin {
+        $f = $MyInvocation.InvocationName
+        Write-Verbose -Message "$f - START"
+        $stringBuilder = New-Object -TypeName System.Text.StringBuilder
     }
-}
 
-End
-{
-    Write-Verbose -Message "$f - END"
-    $stringBuilder.ToString()
-}
+    Process {    
+        if ($Template) {        
+            $null = $stringBuilder.AppendLine('New-ARMtemplate')
+            $null = $stringBuilder.AppendLine()
+
+            Write-Verbose -Message "$f -  Processing variables"
+            [string]$vars = $Template.variables | Get-ARMvariableScript
+            $null = $stringBuilder.AppendLine($vars)
+
+            Write-Verbose -Message "$f -  Processing parameters"
+            [string]$params = $Template.parameters | Get-ARMparameterScript
+            $null = $stringBuilder.AppendLine($params)
+
+            Write-Verbose -Message "$f -  Processing resources"        
+            foreach ($resource in $Template.resources) {
+                [string]$res = $resource | Get-ARMresourceScript
+                $null = $stringBuilder.AppendLine($res)
+            }       
+        }
+    }
+
+    End {
+        Write-Verbose -Message "$f - END"
+        $stringBuilder.ToString()
+    }
 
 }

--- a/Functions/Get-ARMvariable.ps1
+++ b/Functions/Get-ARMvariable.ps1
@@ -1,7 +1,6 @@
 #Requires -Version 5.0
-function Get-ARMvariable
-{
-<#
+function Get-ArmVariable {
+    <#
 .SYNOPSIS
     Get all variable or a specific one by name.
  
@@ -31,66 +30,57 @@ function Get-ARMvariable
     Website: www.firstpoint.no
     Twitter: @ToreGroneng
 #>
-[CmdletBinding()]
-[OutputType('PSCustomObject')]
-Param()
+    [CmdletBinding()]
+    [OutputType('PSCustomObject')]
+    Param()
 
-DynamicParam
-{
-    $Dictionary = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
+    DynamicParam {
+        $Dictionary = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
 
-    $NewDynParam = @{
-        Name = "Name"            
-        Mandatory = $false
-        ValueFromPipelineByPropertyName = $true
-        ValueFromPipeline = $false
-        DPDictionary = $Dictionary            
+        $NewDynParam = @{
+            Name = "Name"            
+            Mandatory = $false
+            ValueFromPipelineByPropertyName = $true
+            ValueFromPipeline = $false
+            DPDictionary = $Dictionary            
+        }
+
+        $allVariables = $script:Template.variables.PSobject.Properties.Name
+
+        if ($allVariables) {
+            $null = $NewDynParam.Add("ValidateSet", $allVariables)
+        }
+        else {
+            $null = $NewDynParam.Add("ValidateSet", @("-"))
+        }
+
+        New-DynamicParam @NewDynParam
+        $Dictionary
     }
 
-    $allVariables = $script:Template.variables.PSobject.Properties.Name
-
-    if ($allVariables)
-    {
-        $null = $NewDynParam.Add("ValidateSet",$allVariables)
-    }
-    else
-    {
-        $null = $NewDynParam.Add("ValidateSet",@("-"))
+    Begin {
+        $f = $MyInvocation.InvocationName
+        Write-Verbose -Message "$f - START"
     }
 
-    New-DynamicParam @NewDynParam
-    $Dictionary
-}
+    Process {       
+        $Name = $PSBoundParameters.Name
 
-Begin 
-{
-    $f = $MyInvocation.InvocationName
-    Write-Verbose -Message "$f - START"
-}
+        if (-not $PSBoundParameters.ContainsKey("Template")) {
+            $Template = $script:Template
+        }
 
-Process 
-{       
-    $Name = $PSBoundParameters.Name
-
-    if (-not $PSBoundParameters.ContainsKey("Template"))
-    {
-        $Template = $script:Template
+        if ($Name) {
+            Write-Verbose -Message "$f -  Finding parameter with name [$Name]"        
+            $Template.variables | Select-Object -Property $Name
+        }
+        else {
+            Write-Verbose -Message "$f -  Returning all variables"            
+            $Template.variables
+        }
     }
 
-    if ($Name)
-    {
-        Write-Verbose -Message "$f -  Finding parameter with name [$Name]"        
-        $Template.variables | Select-Object -Property $Name
+    End {
+        Write-Verbose -Message "$f - START"
     }
-    else 
-    {
-        Write-Verbose -Message "$f -  Returning all variables"            
-        $Template.variables
-    }
-}
-
-End 
-{
-    Write-Verbose -Message "$f - START"
-}
 }

--- a/Functions/Get-ARMvariableScript.ps1
+++ b/Functions/Get-ARMvariableScript.ps1
@@ -1,7 +1,6 @@
 #Requires -Version 5.0
-function Get-ARMvariableScript
-{
-<#
+function Get-ArmVariableScript {
+    <#
 .SYNOPSIS
     Get the Powershell script that will recreate the variables in the ARM template
 
@@ -25,41 +24,37 @@ function Get-ARMvariableScript
     Website: www.firstpoint.no
     Twitter: @ToreGroneng
 #>
-[cmdletbinding()]
-Param(
-    [Parameter(ValueFromPipeline)]
-    [PSCustomObject]
-    $Variables
-)
+    [cmdletbinding()]
+    [outputtype([string])]
+    Param(
+        [Parameter(ValueFromPipeline)]
+        [PSCustomObject]
+        $Variables
+    )
 
-Begin
-{
-    $f = $MyInvocation.InvocationName
-    Write-Verbose -Message "$f - START"    
-    $cmdLine = ""
-}
+    Begin {
+        $f = $MyInvocation.InvocationName
+        Write-Verbose -Message "$f - START"    
+        $cmdLine = ""
+    }
 
-Process
-{    
-    #if ($Variables.variables)
-    if ($Variables)
-    {
-        $allVars = $Variables | ConvertTo-Hash
+    Process {    
+        #if ($Variables.variables)
+        if ($Variables) {
+            $allVars = $Variables | ConvertTo-Hash
 
-        foreach ($key in $allVars.Keys)
-        {
-            Write-Verbose -Message "$f -  Processing key [$key]"
+            foreach ($key in $allVars.Keys) {
+                Write-Verbose -Message "$f -  Processing key [$key]"
 
-            $cmdLine += "New-ARMvariable -Name $key -Value " + '"' + $($allVars.$key) + '" | Add-ARMVariable'
-            $cmdLine += [environment]::NewLine
-        }
-    }    
-}
+                $cmdLine += "New-ARMvariable -Name $key -Value " + '"' + $($allVars.$key) + '" | Add-ARMVariable'
+                $cmdLine += [environment]::NewLine
+            }
+        }    
+    }
 
-End 
-{
-    $cmdLine
-    Write-Verbose -Message "$f - END"
-}
+    End {
+        $cmdLine
+        Write-Verbose -Message "$f - END"
+    }
 
 }

--- a/Functions/Import-ARMtemplate.ps1
+++ b/Functions/Import-ARMtemplate.ps1
@@ -1,7 +1,6 @@
 #Requires -Version 5.0
-function Import-ARMtemplate
-{
-<#
+function Import-ArmTemplate {
+    <#
 .SYNOPSIS
     Import an ARM template.
 
@@ -25,7 +24,7 @@ function Import-ARMtemplate
     Get-ARMtemplate
 
 .EXAMPLE
-    Import-ARMtemplate -FileName .\TestFiles\SimpleVM.json
+    Import-ARMtemplate -FileName .\TestFiles\SiWmpleVM.json
     Get-ARMtemplate
 
 .INPUTS
@@ -39,63 +38,54 @@ function Import-ARMtemplate
     Website: www.firstpoint.no
     Twitter: @ToreGroneng
 #>
-[cmdletbinding()]
-Param(
-    [Parameter(ValueFromPipeline, ParameterSetName="AsString")]
-    [string]
-    $JsonString
-    ,
-    [Parameter(ValueFromPipeline, ValueFromPipelineByPropertyName, ParameterSetName="FromFile")]
-    [System.IO.FileInfo]
-    [Alias("FullName")]
-    $FileName
-    ,
-    [switch]$PassThru
-)
+    [cmdletbinding()]
+    Param(
+        [Parameter(ValueFromPipeline, ParameterSetName = "AsString")]
+        [string]
+        $JsonString
+        ,
+        [Parameter(ValueFromPipeline, ValueFromPipelineByPropertyName, ParameterSetName = "FromFile")]
+        [System.IO.FileInfo]
+        [Alias("FullName")]
+        $FileName
+        ,
+        [switch]$PassThru
+    )
 
-Begin
-{
-    $f = $MyInvocation.InvocationName
-    Write-Verbose -Message "$f - START"
-    $sb = New-Object System.Text.StringBuilder
-}
-
-Process
-{
-    if ($PSBoundParameters.ContainsKey("FileName"))
-    {        
-        $fileNameType = $FileName.GetType().Name
-        if ($fileNameType -eq 'FileInfo')
-        {
-            $FileName = $FileName.FullName
-        }        
-        $JsonString = Get-Content -Path $FileName -Encoding UTF8            
+    Begin {
+        $f = $MyInvocation.InvocationName
+        Write-Verbose -Message "$f - START"
+        $sb = New-Object System.Text.StringBuilder
     }
 
-    if ($JsonString)
-    {
-        $null = $sb.Append($JsonString + [environment]::NewLine)
-    }
-}
+    Process {
+        if ($PSBoundParameters.ContainsKey("FileName")) {        
+            $fileNameType = $FileName.GetType().Name
+            if ($fileNameType -eq 'FileInfo') {
+                $FileName = $FileName.FullName
+            }        
+            $JsonString = Get-Content -Path $FileName -Encoding UTF8            
+        }
 
-End
-{    
-    if ($sb.Length -gt 0)
-    {
-        $jsonString = $sb.ToString()        
-        Write-Verbose -Message "$f - $jsonString"
+        if ($JsonString) {
+            $null = $sb.Append($JsonString + [environment]::NewLine)
+        }
+    }
+
+    End {    
+        if ($sb.Length -gt 0) {
+            $jsonString = $sb.ToString()        
+            Write-Verbose -Message "$f - $jsonString"
         
-        $templateObject = $jsonString | ConvertFrom-Json
+            $templateObject = $jsonString | ConvertFrom-Json
 
-        if ($PassThru.IsPresent)
-        {
-            $templateObject
-        }
-        else
-        {
-            $script:Template = $templateObject
+            if ($PassThru.IsPresent) {
+                $templateObject
+            }
+            else {
+                $script:Template = $templateObject
+            }
         }
     }
-}
 
 }

--- a/Functions/New-ARMfunction.ps1
+++ b/Functions/New-ARMfunction.ps1
@@ -1,37 +1,30 @@
-function New-ARMfunction
-{
-[cmdletbinding()]
-Param(
-    #[Parameter(ParameterSetName='concat')]
-    [switch]$ConCat
-    ,
-    #[Parameter(ParameterSetName='concat')]
-    [string[]]$Values
-)
-    DynamicParam
-    {
+function New-ArmFunction {
+    [cmdletbinding()]
+    [outputtype([string])]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
+    Param(
+        [switch]$ConCat
+        ,
+        [string[]]$Values
+    )
+    DynamicParam {
         $Dictionary = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
 
         $NewDynParam = @{
-            Name = "Variable"            
+            Name = "Variable"
             Mandatory = $false
             ValueFromPipelineByPropertyName = $true
             ValueFromPipeline = $false
-            DPDictionary = $Dictionary            
+            DPDictionary = $Dictionary
         }
-
-        #ParameterSetName = "__AllParameterSets"
-        #ParameterSetName = "ByVariable"
 
         $allVars = $script:Template.variables.Keys
 
-        if ($allVars)
-        {
-            $null = $NewDynParam.Add("ValidateSet",$allVars)
+        if ($allVars) {
+            $null = $NewDynParam.Add("ValidateSet", $allVars)
         }
-        else
-        {
-            $null = $NewDynParam.Add("ValidateSet",@("-"))
+        else {
+            $null = $NewDynParam.Add("ValidateSet", @("-"))
         }
 
         New-DynamicParam @NewDynParam
@@ -40,18 +33,15 @@ Param(
         #$NewDynParam.ParameterSetName = "ByParam"
         $allParams = $script:Template.parameters.Keys
 
-        if (($allParams | Measure-Object).Count -eq 1)
-        {
-            $allParams = @(,$allParams)
+        if (($allParams | Measure-Object).Count -eq 1) {
+            $allParams = @(, $allParams)
         }
 
-        if ($allParams)
-        {
+        if ($allParams) {
             $NewDynParam.ValidateSet = $allParams
         }
-        else
-        {
-            $NewDynParam.ValidateSet = @("empty","box")
+        else {
+            $NewDynParam.ValidateSet = @("empty", "box")
         }
 
         New-DynamicParam @NewDynParam
@@ -61,52 +51,45 @@ Param(
         $Dictionary
     }
 
-Begin
-{
-    $f = $MyInvocation.InvocationName
-    throw "$f is not implemented"
-}
+    Begin {
+        $f = $MyInvocation.InvocationName
+        throw "$f is not implemented"
+    }
 
-Process
-{
-    $var = $PSBoundParameters.Variable
-    $param = $PSBoundParameters.Parameter
+    Process {
+
+        $var = $PSBoundParameters.Variable
+        $param = $PSBoundParameters.Parameter
     
-    $hashKeyIndex = [ordered]@{}
-    $index = 0
-    foreach ($key in $PSBoundParameters.Keys)
-    {
-        $hashKeyIndex.Add($key,$index)
-        $index++
-    }
-
-    if ($ConCat)
-    {
-        $ConcatValue = "[concat('"
-        if ($Values)
-        {
-            return "$ConcatValue$($Values -join "','")))]"
+        $hashKeyIndex = [ordered]@{}
+        $index = 0
+        foreach ($key in $PSBoundParameters.Keys) {
+            $hashKeyIndex.Add($key, $index)
+            $index++
         }
 
-        if ($var -and $param)
-        {
-            $ConcatValue = "[concat("
-            $varValue = "variable('$var')"
-            $paramValue = "parameter('$param')"
-            
-            $paramIndex = $hashKeyIndex.Parameter
-            $varIndex = $hashKeyIndex.Variable
-
-            if ($paramIndex -lt $varIndex)
-            {
-                return "$ConcatValue" + "$paramValue," + "$varValue" + ")]"
+        if ($ConCat) {
+            $ConcatValue = "[concat('"
+            if ($Values) {
+                return "$ConcatValue$($Values -join "','")))]"
             }
-            
-            if ($varIndex -lt $paramIndex)
-            {
-                return "$ConcatValue" + "$varValue," + "$paramValue" + "')]"
-            }            
+
+            if ($var -and $param) {
+                $ConcatValue = "[concat("
+                $varValue = "variable('$var')"
+                $paramValue = "parameter('$param')"
+
+                $paramIndex = $hashKeyIndex.Parameter
+                $varIndex = $hashKeyIndex.Variable
+
+                if ($paramIndex -lt $varIndex) {
+                    return "$ConcatValue" + "$paramValue," + "$varValue" + ")]"
+                }
+
+                if ($varIndex -lt $paramIndex) {
+                    return "$ConcatValue" + "$varValue," + "$paramValue" + "')]"
+                }
+            }
         }
     }
-}
 }

--- a/Functions/New-ARMparameter.ps1
+++ b/Functions/New-ARMparameter.ps1
@@ -1,7 +1,6 @@
 #Requires -Version 5.0
-function New-ARMparameter
-{
-<#    
+function New-ArmParameter {
+    <#    
 .SYNOPSIS    
     Create a new ARM template parameter
 
@@ -26,7 +25,7 @@ function New-ARMparameter
     New-ARMparameter -Name windowsOSVersion -Type String -DefaultValue "2016-Datacenter" @allowedValues
 
     This will create a new parameter named windowsOSVersion of type String, with a default value of "2016-Datacenter" which
-    is in the allowedValues list/array         
+    is in the allowedValues list/array
 
 .INPUTS
     String
@@ -40,76 +39,69 @@ function New-ARMparameter
     Twitter: @ToreGroneng
 #>
     
-[cmdletbinding()]
-Param(
-    [Parameter(Mandatory)]
-    [string]
-    $Name
-    ,
-    [Parameter(Mandatory)]
-    [ValidateSet("string","secureString","int","bool","object","secureObject","array")]
-    [string]
-    $Type
-    ,
-    $DefaultValue
-    ,
-    $AllowedValues
-    ,
-    $MinValue
-    ,
-    $MaxValue
-    ,
-    $MinLength
-    ,
-    $MaxLength
-    ,
-    $Description
-    ,
-    $Metadata
-)
+    [cmdletbinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
+    Param(
+        [Parameter(Mandatory)]
+        [string]
+        $Name
+        ,
+        [Parameter(Mandatory)]
+        [ValidateSet("string", "secureString", "int", "bool", "object", "secureObject", "array")]
+        [string]
+        $Type
+        ,
+        $DefaultValue
+        ,
+        $AllowedValues
+        ,
+        $MinValue
+        ,
+        $MaxValue
+        ,
+        $MinLength
+        ,
+        $MaxLength
+        ,
+        $Description
+        ,
+        $Metadata
+    )
 
     $propHash = [ordered]@{        
         type = $Type
     }
 
-    if ($DefaultValue)
-    {
+    if ($DefaultValue) {
         $null = $propHash.defaultValue = $DefaultValue
     }
 
-    if ($AllowedValues)
-    {
+    if ($AllowedValues) {
         $null = $propHash.allowedValues = $AllowedValues
     }
 
-    if ($MinValue)
-    {
+    if ($MinValue) {
         $null = $propHash.minValue = $MinValue
     }
 
-    if ($MaxValue)
-    {
+    if ($MaxValue) {
         $null = $propHash.maxValue = $MaxValue
     }
 
-    if ($MinLength)
-    {
+    if ($MinLength) {
         $null = $propHash.minLength = $MinLength
     }
 
-    if ($MaxLength)
-    {
+    if ($MaxLength) {
         $null = $propHash.maxLength = $MaxLength
     }
 
-    if ($Description)
-    {
+    if ($Description) {
         Write-Verbose -Message "Adding description"
         $null = $propHash.metadata = @{description = $Description}
     }
 
-    if ($Metadata)
-    {
+    if ($Metadata) {
         $null = $propHash.metadata += $Metadata
     }
 

--- a/Functions/New-ARMresource.ps1
+++ b/Functions/New-ARMresource.ps1
@@ -1,7 +1,6 @@
 #Requires -Version 5.0
-function New-ARMresource
-{
-<#    
+function New-ARMresource {
+    <#    
 .SYNOPSIS    
     Create a new ARM template resource
 
@@ -40,123 +39,111 @@ function New-ARMresource
     Website: www.firstpoint.no
     Twitter: @ToreGroneng
 #>
-[cmdletbinding()]
-Param(
-    [string]
-    $APIversion
-    ,
-    [string]
-    $Name
-    ,
-    [string]
-    $Location
-    ,
-    [hashtable]
-    $Tags
-    ,
-    [string]
-    $Comments
-    ,
-    [string[]]
-    $DependsOn
-    ,
-    [hashtable]
-    $SKU
-    ,
-    [string]
-    $Kind
-    ,
-    [hashtable]
-    $Properties
-    ,
-    [array]
-    $Resources
-)
-DynamicParam
-{
-    $Dictionary = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
+    [cmdletbinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
+    Param(
+        [string]
+        $APIversion
+        ,
+        [string]
+        $Name
+        ,
+        [string]
+        $Location
+        ,
+        [hashtable]
+        $Tags
+        ,
+        [string]
+        $Comments
+        ,
+        [string[]]
+        $DependsOn
+        ,
+        [hashtable]
+        $SKU
+        ,
+        [string]
+        $Kind
+        ,
+        [hashtable]
+        $Properties
+        ,
+        [array]
+        $Resources
+    )
+    DynamicParam {
+        $Dictionary = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
 
-    $NewDynParam = @{
-        Name = "Type"
-        Alias = "ResourceName"
-        Mandatory = $true
-        ValueFromPipelineByPropertyName = $true
-        ValueFromPipeline = $true
-        DPDictionary = $Dictionary
-    }
+        $NewDynParam = @{
+            Name = "Type"
+            Alias = "ResourceName"
+            Mandatory = $true
+            ValueFromPipelineByPropertyName = $true
+            ValueFromPipeline = $true
+            DPDictionary = $Dictionary
+        }
 
-    $all = Get-ARMresourceList -ErrorAction SilentlyContinue
+        $all = Get-ARMresourceList -ErrorAction SilentlyContinue
     
-    if ($all)
-    {
-        $null = $NewDynParam.Add("ValidateSet",$all)
+        if ($all) {
+            $null = $NewDynParam.Add("ValidateSet", $all)
+        }
+
+        New-DynamicParam @NewDynParam
+        $Dictionary
     }
 
-    New-DynamicParam @NewDynParam
-    $Dictionary
-}
-
-Begin
-{
-    $f = $MyInvocation.InvocationName
-    Write-Verbose -Message "$f - START"
-}
-
-Process
-{
-    $ResourceName = $PSBoundParameters.Type
-
-    $propHash = [ordered]@{
-        PSTypeName = "ARMresource"
-        apiVersion = $APIversion
-        type = $ResourceName
+    Begin {
+        $f = $MyInvocation.InvocationName
+        Write-Verbose -Message "$f - START"
     }
 
-    if ($Name)
-    {
-        $propHash["name"] = $Name
-    }
+    Process {
+        $ResourceName = $PSBoundParameters.Type
 
-    if ($Location)
-    {
-        $propHash.location = $Location
-    }
+        $propHash = [ordered]@{
+            PSTypeName = "ARMresource"
+            apiVersion = $APIversion
+            type = $ResourceName
+        }
 
-    if ($DependsOn)
-    {        
-        $propHash.dependsOn = $DependsOn
-    }
+        if ($Name) {
+            $propHash["name"] = $Name
+        }
 
-    if ($Properties)
-    {        
-        $propHash.properties = $Properties
-    }
+        if ($Location) {
+            $propHash.location = $Location
+        }
 
-    if ($Tags)
-    {
-        $propHash.tags = $Tags
-    }
+        if ($DependsOn) {        
+            $propHash.dependsOn = $DependsOn
+        }
 
-    if ($Comments)
-    {
-        $propHash.comments = $Comments
-    }       
+        if ($Properties) {        
+            $propHash.properties = $Properties
+        }
+
+        if ($Tags) {
+            $propHash.tags = $Tags
+        }
+
+        if ($Comments) {
+            $propHash.comments = $Comments
+        }       
     
-    if ($Resources)
-    {        
-        $propHash.resources = $Resources
-    }
+        if ($Resources) {        
+            $propHash.resources = $Resources
+        }
 
-    if ($SKU)
-    {        
-        $propHash.SKU = $SKU
-    }
+        if ($SKU) {        
+            $propHash.SKU = $SKU
+        }
 
-    if ($Kind)
-    {        
-        $propHash.kind = $Kind
-    }
+        if ($Kind) {        
+            $propHash.kind = $Kind
+        }
 
-    [PSCustomObject]$propHash
-}
+        [PSCustomObject]$propHash
+    }
 }

--- a/Functions/New-ARMvariable.ps1
+++ b/Functions/New-ARMvariable.ps1
@@ -1,7 +1,6 @@
 #Requires -Version 5.0
-function New-ARMvariable
-{
-<#    
+function New-ArmVariable {
+    <#    
 .SYNOPSIS    
     Create a new ARM template variable
 
@@ -41,52 +40,48 @@ function New-ARMvariable
     Website: www.firstpoint.no
     Twitter: @ToreGroneng
 #>
-[cmdletbinding()]
-Param(
-    [Parameter(Mandatory)]
-    [string]
-    $Name
-    ,
-    [Parameter(ParameterSetName='Simple')]
-    [string]
-    $Value
-    ,
-    [Parameter(
-        ValueFromPipeline,
-        ParameterSetName='Complex'
-    )]
-    [hashtable]
-    $HashValues
-)
-Begin
-{
-    $f = $MyInvocation.InvocationName
-    Write-Verbose -Message "$f - START"        
-}
-
-Process
-{
-    if ($PSCmdlet.ParameterSetName -eq "Simple")
-    {        
-        $propHash = [PSCustomObject][ordered]@{
-            PSTypeName = "ARMvariable"
-            $Name = $Value
-        }
+    [cmdletbinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
+    Param(
+        [Parameter(Mandatory)]
+        [string]
+        $Name
+        ,
+        [Parameter(ParameterSetName = 'Simple')]
+        [string]
+        $Value
+        ,
+        [Parameter(
+            ValueFromPipeline,
+            ParameterSetName = 'Complex'
+        )]
+        [hashtable]
+        $HashValues
+    )
+    Begin {
+        $f = $MyInvocation.InvocationName
+        Write-Verbose -Message "$f - START"        
     }
 
-    if ($PSCmdlet.ParameterSetName -eq "Complex")
-    {        
-        $propHash = [PSCustomObject][ordered]@{
-            PSTypeName = "ARMvariable"
-            $Name = [PSCustomObject]$HashValues
+    Process {
+        if ($PSCmdlet.ParameterSetName -eq "Simple") {        
+            $propHash = [PSCustomObject][ordered]@{
+                PSTypeName = "ARMvariable"
+                $Name = $Value
+            }
         }
-    }
-    $propHash
-}
 
-End
-{
-    Write-Verbose -Message "$f - END"
-}
+        if ($PSCmdlet.ParameterSetName -eq "Complex") {        
+            $propHash = [PSCustomObject][ordered]@{
+                PSTypeName = "ARMvariable"
+                $Name = [PSCustomObject]$HashValues
+            }
+        }
+        $propHash
+    }
+
+    End {
+        Write-Verbose -Message "$f - END"
+    }
 
 }

--- a/Functions/New-ArmTemplate.ps1
+++ b/Functions/New-ArmTemplate.ps1
@@ -1,28 +1,26 @@
-function New-ARMTemplate
-{
-[cmdletbinding()]
-Param(
-    $schema = "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#"
-    ,
-    [switch]$Passthru
-)
-$templateObject = [pscustomobject][ordered]@{
-    '$schema' = $schema
-    contentVersion = "1.0.0.0"
-    parameters = [pscustomobject]@{}
-    variables = [pscustomobject]@{}
-    resources =  @()
-    outputs = [pscustomobject]@{}
-}
+function New-ArmTemplate {
+    [cmdletbinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
+    Param(
+        $schema = "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#"
+        ,
+        [switch]$Passthru
+    )
+    $templateObject = [pscustomobject][ordered]@{
+        '$schema' = $schema
+        contentVersion = "1.0.0.0"
+        parameters = [pscustomobject]@{}
+        variables = [pscustomobject]@{}
+        resources = @()
+        outputs = [pscustomobject]@{}
+    }
 
-if ($script:Template)
-{
-    $script:Template = $templateObject
-}
+    if ($script:Template) {
+        $script:Template = $templateObject
+    }
 
-if ($Passthru.IsPresent)
-{
-    $templateObject
-}
+    if ($Passthru.IsPresent) {
+        $templateObject
+    }
 
 }

--- a/Functions/New-DynamicParam.ps1
+++ b/Functions/New-DynamicParam.ps1
@@ -1,7 +1,6 @@
-function New-DynamicParam 
-{
-[cmdletbinding()]
-<#
+function New-DynamicParam {
+    [cmdletbinding()]
+    <#
     .SYNOPSIS
         Helper function to simplify creating dynamic parameters
     
@@ -150,41 +149,41 @@ function New-DynamicParam
         PowerShell Language
 
 #>
-param(    
-    [string]$Name
-    ,
-    [System.Type]$Type = [string]
-    ,
-    [string]$TypeAsString
-    ,
-    [string[]]$Alias = @()
-    ,
-    [string[]]$ValidateSet
-    ,    
-    [scriptblock]$validateScript
-    ,
-    [switch]$Mandatory
-    ,    
-    [string]$ParameterSetName = "__AllParameterSets"
-    ,    
-    [int]$Position
-    ,    
-    [switch]$ValueFromPipelineByPropertyName
-    ,
-    [switch]$ValueFromPipeline
-    ,    
-    [string]$HelpMessage
-    ,
-    [validatescript({
-        if (-not ( $_ -is [System.Management.Automation.RuntimeDefinedParameterDictionary] -or -not $_) )
-        {
-            Throw "DPDictionary must be a System.Management.Automation.RuntimeDefinedParameterDictionary object, or not exist"
-        }
-        $True
-    })]
-    $DPDictionary = $false
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
+    param(    
+        [string]$Name
+        ,
+        [System.Type]$Type = [string]
+        ,
+        [string]$TypeAsString
+        ,
+        [string[]]$Alias = @()
+        ,
+        [string[]]$ValidateSet
+        ,    
+        [scriptblock]$validateScript
+        ,
+        [switch]$Mandatory
+        ,    
+        [string]$ParameterSetName = "__AllParameterSets"
+        ,    
+        [int]$Position
+        ,    
+        [switch]$ValueFromPipelineByPropertyName
+        ,
+        [switch]$ValueFromPipeline
+        ,    
+        [string]$HelpMessage
+        ,
+        [validatescript( {
+                if (-not ( $_ -is [System.Management.Automation.RuntimeDefinedParameterDictionary] -or -not $_) ) {
+                    Throw "DPDictionary must be a System.Management.Automation.RuntimeDefinedParameterDictionary object, or not exist"
+                }
+                $True
+            })]
+        $DPDictionary = $false
  
-)
+    )
     Add-Type @"
     public class DynParamQuotedString {
  
@@ -207,70 +206,60 @@ param(
         }
     }
 "@ 
-    if ($PSBoundParameters.ContainsKey("TypeAsString"))
-    {
+    if ($PSBoundParameters.ContainsKey("TypeAsString")) {
         $type = [System.Type]$TypeAsString
     }
     #Create attribute object, add attributes, add to collection   
-        $ParamAttr = New-Object System.Management.Automation.ParameterAttribute
-        $ParamAttr.ParameterSetName = $ParameterSetName
+    $ParamAttr = New-Object System.Management.Automation.ParameterAttribute
+    $ParamAttr.ParameterSetName = $ParameterSetName
         
-        if ($mandatory)
-        {
-            $ParamAttr.Mandatory = $True
-        }
-        if ($Position -ne $null)
-        {
-            $ParamAttr.Position=$Position
-        }
-        if ($ValueFromPipelineByPropertyName)
-        {
-            $ParamAttr.ValueFromPipelineByPropertyName = $True            
-        }
-        if ($ValueFromPipeline)
-        {
-            $ParamAttr.ValueFromPipeline = $True
-        }
-        if ($HelpMessage)
-        {
-            $ParamAttr.HelpMessage = $HelpMessage
-        }
+    if ($mandatory) {
+        $ParamAttr.Mandatory = $True
+    }
+    if ($null -ne $Position) {
+        $ParamAttr.Position = $Position
+    }
+    if ($ValueFromPipelineByPropertyName) {
+        $ParamAttr.ValueFromPipelineByPropertyName = $True            
+    }
+    if ($ValueFromPipeline) {
+        $ParamAttr.ValueFromPipeline = $True
+    }
+    if ($HelpMessage) {
+        $ParamAttr.HelpMessage = $HelpMessage
+    }
  
-        $AttributeCollection = New-Object 'Collections.ObjectModel.Collection[System.Attribute]'
-        $AttributeCollection.Add($ParamAttr)
+    $AttributeCollection = New-Object 'Collections.ObjectModel.Collection[System.Attribute]'
+    $AttributeCollection.Add($ParamAttr)
     
     #param validation set if specified
-        if ($ValidateSet)
-        {
-            $ParamOptions = New-Object System.Management.Automation.ValidateSetAttribute -ArgumentList $ValidateSet
-            $AttributeCollection.Add($ParamOptions)
-        }
+    if ($ValidateSet) {
+        $ParamOptions = New-Object System.Management.Automation.ValidateSetAttribute -ArgumentList $ValidateSet
+        $AttributeCollection.Add($ParamOptions)
+    }
         
-        if ($validateScript)
-        {
-            $paramScript = New-Object -TypeName System.Management.Automation.ValidateScriptAttribute -ArgumentList $validateScript
-            $AttributeCollection.Add($paramScript)
-        }
+    if ($validateScript) {
+        $paramScript = New-Object -TypeName System.Management.Automation.ValidateScriptAttribute -ArgumentList $validateScript
+        $AttributeCollection.Add($paramScript)
+    }
 
     #Aliases if specified
-        if ($Alias.count -gt 0) {
-            $ParamAlias = New-Object System.Management.Automation.AliasAttribute -ArgumentList $Alias
-            $AttributeCollection.Add($ParamAlias)
-        }
+    if ($Alias.count -gt 0) {
+        $ParamAlias = New-Object System.Management.Automation.AliasAttribute -ArgumentList $Alias
+        $AttributeCollection.Add($ParamAlias)
+    }
 
  
     #Create the dynamic parameter
-        $Parameter = New-Object -TypeName System.Management.Automation.RuntimeDefinedParameter -ArgumentList @($Name, $Type, $AttributeCollection)
+    $Parameter = New-Object -TypeName System.Management.Automation.RuntimeDefinedParameter -ArgumentList @($Name, $Type, $AttributeCollection)
     
     #Add the dynamic parameter to an existing dynamic parameter dictionary, or create the dictionary and add it
-        if ($DPDictionary)
-        {
-            $DPDictionary.Add($Name, $Parameter)
-        }
-        else
-        {
-            $Dictionary = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
-            $Dictionary.Add($Name, $Parameter)
-            $Dictionary
-        }
+    if ($DPDictionary) {
+        $DPDictionary.Add($Name, $Parameter)
+    }
+    else {
+        $Dictionary = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
+        $Dictionary.Add($Name, $Parameter)
+        $Dictionary
+    }
 }

--- a/Functions/Out-HashString.ps1
+++ b/Functions/Out-HashString.ps1
@@ -1,6 +1,5 @@
-function Out-HashString
-{
-<#
+function Out-HashString {
+    <#
 .SYNOPSIS
     Convert an hashtable or and OrderedDictionary to a string
 
@@ -37,120 +36,102 @@ function Out-HashString
     Website: www.firstpoint.no
     Twitter: @ToreGroneng
 #>
-[cmdletbinding()]
-Param(
-    [Parameter(ValueFromPipeLine)]
-    $InputObject
-    ,
-    [string]$PreSpacing = "    "
-)
-Begin
-{
-    $f = $MyInvocation.InvocationName
-    Write-Verbose -Message "$f - START"
-    $newLine = [environment]::NewLine
+    [cmdletbinding()]
+    [OutputType([string])]
+    Param(
+        [Parameter(ValueFromPipeLine)]
+        $InputObject
+        ,
+        [string]$PreSpacing = "    "
+    )
+    Begin {
+        $f = $MyInvocation.InvocationName
+        Write-Verbose -Message "$f - START"
+        $newLine = [environment]::NewLine
 
-    if ($PreSpacing)
-    {
-        $endspaceCount = $PreSpacing.Length - 4
-        if ($endspaceCount -lt 0){$endspaceCount = 0}
-        $endspace = " " * $endspaceCount
-        $beginSpace = " " * $endspaceCount
-    }   
-}
-Process
-{
-    $out = "@{"
-    
-    $out = $out + $newLine
-    $preSpace = $PreSpacing
-
-    if (-not $InputObject -or $InputObject.keys.count -eq 0) {return "@{}"}
-
-    foreach ($key in $InputObject.Keys)
-    {
-        Write-Verbose -Message "$f -  Processing key [$key]"
-
-        if ($key.Contains('$'))
-        {
-            $DisplayKey = "'$key'"
-        }
-
-        $value = $InputObject.$key
-        $objType = $value.GetType().Name
-        Write-Verbose -Message "$f -  ObjectType = $objType"
-        
-        $mode = "stringValue"
-
-        if ($objType -eq "Hashtable" -or $objType -eq "OrderedDictionary")
-        {
-            $mode = "hashtable"
-        }
-        
-        if ($value -is [array])
-        {
-            if ($value[0])
-            {
-                $arrayType = $value[0].GetType().Name
-                Write-Verbose -Message "$f -  arrayType is [$arrayType]"
-                
-                if ($arrayType -eq "Hashtable" -or $arrayType -eq "OrderedDictionary")
-                {
-                    $mode = "HashTableValue"
-                }
-                else
-                {
-                    $mode = "ArrayValue"
-                }
-            }            
-        }
-        
-        Write-Verbose -Message "$f -  Mode is [$mode]"
-        if ($DisplayKey)
-        {
-            $key = $DisplayKey
-            $DisplayKey = $null
-        }
-
-        $out += "$PreSpacing$key = "
-        
-        switch ($mode)
-        {
-            'stringValue' 
-            {
-                $out += '"' + $value + '"' + $newLine 
-            }
-
-            'hashtable'
-            {               
-                $stringValue = Out-HashString -InputObject $value -PreSpacing "$PreSpacing    "
-                $out += $stringValue + $newLine
-            }
-
-            'HashTableValue'
-            {
-                $stringValue = ""
-                foreach ($arrayHash in $value)
-                {                                       
-                    $hashString = Out-HashString -InputObject $arrayHash -PreSpacing "$PreSpacing    "
-                    $hash = "    $hashString"
-                    $hash = "$hash," + $newLine
-                    $stringValue += $hash
-                }
-                $separatorIndex = $stringValue.LastIndexOf(",")
-                $stringValue = $stringValue.Remove($separatorIndex,1)                
-                $out += $stringValue
-            }
-
-            'ArrayValue'
-            {
-                $out += '"' +($value -join '","') + '"' + $newLine
-            }
-            
-            Default {}
-        }
+        if ($PreSpacing) {
+            $endspaceCount = $PreSpacing.Length - 4
+            if ($endspaceCount -lt 0) {$endspaceCount = 0}
+            $endspace = " " * $endspaceCount
+        }   
     }
-    $out += "$endspace}"
-    $out          
-}
+    Process {
+        $out = "@{"
+    
+        $out = $out + $newLine
+
+        if (-not $InputObject -or $InputObject.keys.count -eq 0) {return "@{}"}
+
+        foreach ($key in $InputObject.Keys) {
+            Write-Verbose -Message "$f -  Processing key [$key]"
+
+            if ($key.Contains('$')) {
+                $DisplayKey = "'$key'"
+            }
+
+            $value = $InputObject.$key
+            $objType = $value.GetType().Name
+            Write-Verbose -Message "$f -  ObjectType = $objType"
+        
+            $mode = "stringValue"
+
+            if ($objType -eq "Hashtable" -or $objType -eq "OrderedDictionary") {
+                $mode = "hashtable"
+            }
+        
+            if ($value -is [array]) {
+                if ($value[0]) {
+                    $arrayType = $value[0].GetType().Name
+                    Write-Verbose -Message "$f -  arrayType is [$arrayType]"
+                
+                    if ($arrayType -eq "Hashtable" -or $arrayType -eq "OrderedDictionary") {
+                        $mode = "HashTableValue"
+                    }
+                    else {
+                        $mode = "ArrayValue"
+                    }
+                }            
+            }
+        
+            Write-Verbose -Message "$f -  Mode is [$mode]"
+            if ($DisplayKey) {
+                $key = $DisplayKey
+                $DisplayKey = $null
+            }
+
+            $out += "$PreSpacing$key = "
+        
+            switch ($mode) {
+                'stringValue' {
+                    $out += '"' + $value + '"' + $newLine 
+                }
+
+                'hashtable' {               
+                    $stringValue = Out-HashString -InputObject $value -PreSpacing "$PreSpacing    "
+                    $out += $stringValue + $newLine
+                }
+
+                'HashTableValue' {
+                    $stringValue = ""
+                    foreach ($arrayHash in $value) {                                       
+                        $hashString = Out-HashString -InputObject $arrayHash -PreSpacing "$PreSpacing    "
+                        $hash = "    $hashString"
+                        $hash = "$hash," + $newLine
+                        $stringValue += $hash
+                    }
+                    $separatorIndex = $stringValue.LastIndexOf(",")
+                    $stringValue = $stringValue.Remove($separatorIndex, 1)                
+                    $out += $stringValue
+                }
+
+                'ArrayValue' {
+                    $out += '"' + ($value -join '","') + '"' + $newLine
+                }
+            
+                Default {}
+            }
+        }
+        $out += "$endspace}"
+        $out          
+    }
 }

--- a/Functions/Set-ARMmetadata.ps1
+++ b/Functions/Set-ARMmetadata.ps1
@@ -1,6 +1,5 @@
-function Set-ARMmetadata
-{
-<#
+function Set-ArmMetadata {
+    <#
 .SYNOPSIS
     Creates a metadata.json file for your ARM template
 
@@ -28,25 +27,25 @@ function Set-ARMmetadata
     Website: www.firstpoint.no
     Twitter: @ToreGroneng
 #>
-[cmdletbinding()]
-Param(
-    $ItemDisplayName
-    ,
-    $Description
-    ,
-    $Summary
-    ,
-    $GitHubUsername
-    ,
-    $FileName = "metadata.json"
-)
+    [cmdletbinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
+    Param(
+        $ItemDisplayName
+        ,
+        $Description
+        ,
+        $Summary
+        ,
+        $GitHubUsername
+        ,
+        $FileName = "metadata.json"
+    )
     $f = $MyInvocation.InvocationName
     Write-Verbose -Message "$f - START"
 
     $resolvedFilename = Resolve-Path -Path $FileName -ErrorAction SilentlyContinue
     
-    if (-not $resolvedFilename)
-    {
+    if (-not $resolvedFilename) {
         $resolvedFilename = Join-Path -Path $PSScriptRoot -ChildPath metadata.json
     }
 

--- a/Functions/Set-ARMvariable.ps1
+++ b/Functions/Set-ARMvariable.ps1
@@ -1,7 +1,6 @@
 #Requires -Version 5.0
-function Set-ARMvariable
-{
-<#
+function Set-ArmVariable {
+    <#
 .SYNOPSIS
     Update an existing variable in the ARM template
 
@@ -29,61 +28,55 @@ function Set-ARMvariable
     Twitter: @ToreGroneng
 #>
 
-[cmdletbinding()]
-Param(    
-    [Parameter(Mandatory)]
-    $Value
-)
+    [cmdletbinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
+    Param(    
+        [Parameter(Mandatory)]
+        $Value
+    )
 
-DynamicParam
-{
-    $Dictionary = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
+    DynamicParam {
+        $Dictionary = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
 
-    $NewDynParam = @{
-        Name = "Name"            
-        Mandatory = $true
-        ValueFromPipelineByPropertyName = $true
-        ValueFromPipeline = $false
-        DPDictionary = $Dictionary            
-    }
+        $NewDynParam = @{
+            Name = "Name"            
+            Mandatory = $true
+            ValueFromPipelineByPropertyName = $true
+            ValueFromPipeline = $false
+            DPDictionary = $Dictionary            
+        }
     
-    $allVariables = $script:Template.variables.PSobject.Properties.Name
+        $allVariables = $script:Template.variables.PSobject.Properties.Name
 
-    if ($allVariables)
-    {
-        $null = $NewDynParam.Add("ValidateSet",$allVariables)
+        if ($allVariables) {
+            $null = $NewDynParam.Add("ValidateSet", $allVariables)
+        }
+        else {
+            $null = $NewDynParam.Add("ValidateSet", @("-"))
+        }
+
+        New-DynamicParam @NewDynParam
+        $Dictionary
     }
-    else
-    {
-        $null = $NewDynParam.Add("ValidateSet",@("-"))
+
+    Begin {
+        $f = $MyInvocation.InvocationName
+        Write-Verbose -Message "$f - START"    
     }
 
-    New-DynamicParam @NewDynParam
-    $Dictionary
-}
+    Process {
+        $Name = $PSBoundParameters.Name    
 
-Begin
-{
-    $f = $MyInvocation.InvocationName
-    Write-Verbose -Message "$f - START"    
-}
-
-Process
-{
-    $Name = $PSBoundParameters.Name    
-
-    $oldValue = Get-ARMVariable -Name $Name | Select-Object -ExpandProperty $Name
-    Write-Verbose -Message "$f -  Updating variable [$Name] from '$oldValue' to '$Value"
+        $oldValue = Get-ARMVariable -Name $Name | Select-Object -ExpandProperty $Name
+        Write-Verbose -Message "$f -  Updating variable [$Name] from '$oldValue' to '$Value"
     
-    if ($script:Template)
-    {
-        $script:Template.variables.$name = $Value
+        if ($script:Template) {
+            $script:Template.variables.$name = $Value
+        }
     }
-}
 
-End
-{
-    Write-Verbose -Message "$f - END"
+    End {
+        Write-Verbose -Message "$f - END"
     
-}
+    }
 }

--- a/Functions/Update-ARMresourceList.ps1
+++ b/Functions/Update-ARMresourceList.ps1
@@ -1,7 +1,6 @@
 #Requires -Version 5.0
-function Update-ARMresourceList
-{
-<#
+function Update-ArmResourceList {
+    <#
 .SYNOPSIS
     This will update the allResources.json file that is used as input when creating a New-ARMresource
 
@@ -38,40 +37,34 @@ function Update-ARMresourceList
     Website: www.firstpoint.no
     Twitter: @ToreGroneng
 #>
-[cmdletbinding(
-    SupportsShouldProcess=$true
-)]
-Param(
-    [pscredential]$Credential
-    ,
-    [switch]$Force
-)
+    [cmdletbinding(
+        SupportsShouldProcess = $true
+    )]
+    Param(
+        [pscredential]$Credential
+        ,
+        [switch]$Force
+    )
     $LoggedIn = $false
     $f = $MyInvocation.InvocationName
     Write-Verbose -Message "$f - START"
 
-    try
-    {
+    try {
         Write-Verbose -Message "$f - Getting AzureRMContext"
         
         Get-AzureRmContext
         $LoggedIn = $true
     }
-    catch
-    {
-        $ex = $_.Exception
+    catch {
         Write-Verbose -Message "$f -  Get-AzureRmContext threw an exception, propably not loggedin"
     }
 
-    if ($LoggedIn -eq $false)
-    {
-        if ($Credential)
-        {
+    if ($LoggedIn -eq $false) {
+        if ($Credential) {
             Write-Verbose -Message "$f -  Invoking Login-AzureRmAccount with credentials"
             Login-AzureRmAccount -Credential $Credential -ErrorAction Stop
         }
-        else
-        {
+        else {
             Write-Verbose -Message "$f -  Invoking Login-AzureRmAccount without credentials"
             Login-AzureRmAccount -ErrorAction Stop
         }
@@ -82,14 +75,12 @@ Param(
     $outFile = @{}
     $shouldProcessOperation = "Creating file"
     
-    if ($Force.IsPresent)
-    {
+    if ($Force.IsPresent) {
         $outFile.Add("Force", $true)
         $shouldProcessOperation = "Overwriting file"
     }
    
-    if ($pscmdlet.ShouldProcess("$fileName", $shouldProcessOperation))
-    {
+    if ($pscmdlet.ShouldProcess("$fileName", $shouldProcessOperation)) {
         Write-Verbose -Message "$f -  Getting a providerlist, saving to [$fileName]"
         Get-AzureRmResourceProvider -ListAvailable | ConvertTo-Json -Depth 10 | Out-File -FilePath "$fileName" -Encoding utf8 @outFile
     }

--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -1,0 +1,40 @@
+@{
+    Severity = @('Error', 'Warning')
+
+    # Example explicit inclusions or exclusions
+     
+    # IncludeRules = @('PSAvoidDefaultValueSwitchParameter',
+    #                 'PSMissingModuleManifestField',
+    #                 'PSReservedCmdletChar',
+    #                 'PSReservedParams',
+    #                 'PSShouldProcess',
+    #                 'PSUseApprovedVerbs',
+    #                 'PSUseDeclaredVarsMoreThanAssigments')
+
+    # ExcludeRules = @('PSAvoidUsingWriteHost', 'PSAvoidGlobalVars')
+
+    Rules = @{
+        PSPlaceOpenBrace = @{
+            Enable = $true
+            OnSameLine = $true
+            NewLineAfter = $true
+        }
+
+        PSPlaceCloseBrace = @{
+            Enable = $false
+        }
+
+        PSUseConsistentIndentation = @{
+            Enable = $true
+            IndentationSize = 4
+        }
+
+        PSUseWhitespace = @{
+            Enable = $true
+            CheckOpenBrace = $true
+            CheckOpenParen = $true
+            CheckOperator = $true
+            CheckSeparator = $true
+        }
+    }
+}

--- a/PoshARM.psd1
+++ b/PoshARM.psd1
@@ -8,116 +8,116 @@
 
 @{
 
-# Script module or binary module file associated with this manifest.
-RootModule = 'PoshARM.psm1'
+    # Script module or binary module file associated with this manifest.
+    RootModule = 'PoshARM.psm1'
 
-# Version number of this module.
-ModuleVersion = '0.1.0.0'
+    # Version number of this module.
+    ModuleVersion = '0.1.0.0'
 
-# Supported PSEditions
-# CompatiblePSEditions = @()
+    # Supported PSEditions
+    # CompatiblePSEditions = @()
 
-# ID used to uniquely identify this module
-GUID = '3153c88f-b648-4492-9ac3-a942d26c4903'
+    # ID used to uniquely identify this module
+    GUID = '3153c88f-b648-4492-9ac3-a942d26c4903'
 
-# Author of this module
-Author = 'Tore Groneng'
+    # Author of this module
+    Author = 'Tore Groneng'
 
-# Company or vendor of this module
-CompanyName = 'Firstpoint AS'
+    # Company or vendor of this module
+    CompanyName = 'Firstpoint AS'
 
-# Copyright statement for this module
-Copyright = '(c) 2016 Tore Groneng. All rights reserved. '
+    # Copyright statement for this module
+    Copyright = '(c) 2016 Tore Groneng. All rights reserved. '
 
-# Description of the functionality provided by this module
-Description = 'A Powershell module for Azure ARM templates. Create templates with Powershell.'
+    # Description of the functionality provided by this module
+    Description = 'A Powershell module for Azure ARM templates. Create templates with Powershell.'
 
-# Minimum version of the Windows PowerShell engine required by this module
- PowerShellVersion = '5.0'
+    # Minimum version of the Windows PowerShell engine required by this module
+    PowerShellVersion = '5.0'
 
-# Name of the Windows PowerShell host required by this module
-# PowerShellHostName = ''
+    # Name of the Windows PowerShell host required by this module
+    # PowerShellHostName = ''
 
-# Minimum version of the Windows PowerShell host required by this module
-# PowerShellHostVersion = ''
+    # Minimum version of the Windows PowerShell host required by this module
+    # PowerShellHostVersion = ''
 
-# Minimum version of Microsoft .NET Framework required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
-# DotNetFrameworkVersion = ''
+    # Minimum version of Microsoft .NET Framework required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
+    # DotNetFrameworkVersion = ''
 
-# Minimum version of the common language runtime (CLR) required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
-# CLRVersion = ''
+    # Minimum version of the common language runtime (CLR) required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
+    # CLRVersion = ''
 
-# Processor architecture (None, X86, Amd64) required by this module
-# ProcessorArchitecture = ''
+    # Processor architecture (None, X86, Amd64) required by this module
+    # ProcessorArchitecture = ''
 
-# Modules that must be imported into the global environment prior to importing this module
-# RequiredModules = @()
+    # Modules that must be imported into the global environment prior to importing this module
+    # RequiredModules = @()
 
-# Assemblies that must be loaded prior to importing this module
-# RequiredAssemblies = @()
+    # Assemblies that must be loaded prior to importing this module
+    # RequiredAssemblies = @()
 
-# Script files (.ps1) that are run in the caller's environment prior to importing this module.
-# ScriptsToProcess = @()
+    # Script files (.ps1) that are run in the caller's environment prior to importing this module.
+    # ScriptsToProcess = @()
 
-# Type files (.ps1xml) to be loaded when importing this module
-# TypesToProcess = @()
+    # Type files (.ps1xml) to be loaded when importing this module
+    # TypesToProcess = @()
 
-# Format files (.ps1xml) to be loaded when importing this module
-# FormatsToProcess = @()
+    # Format files (.ps1xml) to be loaded when importing this module
+    # FormatsToProcess = @()
 
-# Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
-# NestedModules = @()
+    # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
+    # NestedModules = @()
 
-# Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = 'Add-ARMparameter','Add-ARMresource','Add-ARMvariable','ConvertTo-Hash','Get-ARMparameter','Get-ARMparameterScript','Get-ARMresourceList','Get-ARMresourceScript','Get-ARMtemplate','Get-ARMtemplateScript','Get-ARMvariable','Get-ARMvariableScript','Get-FunctionList','Import-ARMtemplate','New-ARMfunction','New-ARMparameter','New-ARMresource','New-ARMTemplate','New-ARMvariable','New-DynamicParam','Out-HashString','Set-ARMmetadata','Set-ARMparameter','Set-ARMvariable','Update-ARMresourceList'
+    # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
+    FunctionsToExport = 'Add-ArmParameter', 'Add-ArmResource', 'Add-ArmVariable', 'ConvertTo-Hash', 'Get-ArmParameter', 'Get-ArmParameterScript', 'Get-ArmResourceList', 'Get-ArmResourceScript', 'Get-ArmTemplate', 'Get-ArmTemplateScript', 'Get-ArmVariable', 'Get-ArmVariableScript', 'Get-FunctionList', 'Import-ArmTemplate', 'New-ArmFunction', 'New-ArmParameter', 'New-ArmResource', 'New-ArmTemplate', 'New-ArmVariable', 'New-DynamicParam', 'Out-HashString', 'Set-ArmMetadata', 'Set-ArmParameter', 'Set-ArmVariable', 'Update-ArmResourceList'
 
-# Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
-CmdletsToExport = '*'
+    # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
+    CmdletsToExport = ''
 
-# Variables to export from this module
-VariablesToExport = '*'
+    # Variables to export from this module
+    VariablesToExport = ''
 
-# Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-AliasesToExport = @()
+    # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
+    AliasesToExport = @()
 
-# DSC resources to export from this module
-# DscResourcesToExport = @()
+    # DSC resources to export from this module
+    # DscResourcesToExport = @()
 
-# List of all modules packaged with this module
-# ModuleList = @()
+    # List of all modules packaged with this module
+    # ModuleList = @()
 
-# List of all files packaged with this module
-# FileList = @()
+    # List of all files packaged with this module
+    # FileList = @()
 
-# Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
-PrivateData = @{
+    # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
+    PrivateData = @{
 
-    PSData = @{
+        PSData = @{
 
-        # Tags applied to this module. These help with module discovery in online galleries.
-        Tags = @('Azure','Template','ARM','JSON','Resource','Manager','Convert','Import')
+            # Tags applied to this module. These help with module discovery in online galleries.
+            Tags = @('Azure', 'Template', 'ARM', 'JSON', 'Resource', 'Manager', 'Convert', 'Import')
 
-        # A URL to the license for this module.
-        # LicenseUri = ''
+            # A URL to the license for this module.
+            # LicenseUri = ''
 
-        # A URL to the main website for this project.
-        ProjectUri = 'https://github.com/torgro/PoshARM'
+            # A URL to the main website for this project.
+            ProjectUri = 'https://github.com/torgro/PoshARM'
 
-        # A URL to an icon representing this module.
-        # IconUri = ''
+            # A URL to an icon representing this module.
+            # IconUri = ''
 
-        # ReleaseNotes of this module
-        # ReleaseNotes = ''
+            # ReleaseNotes of this module
+            # ReleaseNotes = ''
 
-    } # End of PSData hashtable
+        } # End of PSData hashtable
 
-} # End of PrivateData hashtable
+    } # End of PrivateData hashtable
 
-# HelpInfo URI of this module
-# HelpInfoURI = ''
+    # HelpInfo URI of this module
+    # HelpInfoURI = ''
 
-# Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
-# DefaultCommandPrefix = ''
+    # Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
+    # DefaultCommandPrefix = ''
 
 }
 

--- a/PoshARM.psm1
+++ b/PoshARM.psm1
@@ -1,15 +1,11 @@
 $script:Template = [PSCustomObject]@{}
 
-foreach ($file in (Get-ChildItem -file -Path(Join-Path -Path $PSScriptRoot -ChildPath .\functions)))
-{    
+foreach ($file in (Get-ChildItem -file -Path(Join-Path -Path $PSScriptRoot -ChildPath .\functions))) {
     . ([Scriptblock]::Create([System.IO.File]::ReadAllText($file.FullName, [System.Text.Encoding]::UTF8)))
 }
 
-
-
-function Get-FunctionList
-{
-<#
+function Get-FunctionList {
+    <#
 .SYNOPSIS
     Internal function
 
@@ -21,20 +17,18 @@ function Get-FunctionList
     Website: www.firstpoint.no
     Twitter: @ToreGroneng
 #>
-Param(
-    [switch]
-    $AsString
-)
+    Param(
+        [switch]
+        $AsString
+    )
     $functions = (Get-Command -Module posharm | Select-Object -Property Name)
-    $functionsString = ($functions.Name)  -join "','"
+    $functionsString = ($functions.Name) -join "','"
     $functionsString = "'$functionsString'"
 
-    if ($AsString.IsPresent)
-    {
+    if ($AsString.IsPresent) {
         $functionsString
     }
-    else
-    {
+    else {
         $functions
     }
 }

--- a/Tests/Add-ARMparameter.Tests.ps1
+++ b/Tests/Add-ARMparameter.Tests.ps1
@@ -19,7 +19,7 @@ Describe "Add-ARMparameter" {
         MinLength = '3'
         MaxLength = '99'
         Description = 'Description'
-        Metadata = @{Comment="yalla"}
+        Metadata = @{Comment = "yalla"}
     }
 
     $actual = New-ARMparameter @expected

--- a/Tests/Add-ARMresource.Tests.ps1
+++ b/Tests/Add-ARMresource.Tests.ps1
@@ -13,12 +13,12 @@ Describe "Add-ARMresource" {
         APIversion = '2016-03-30'
         Name = 'MyVM'
         Location = 'EAST-US'
-        Tags = @{tag=1}
+        Tags = @{tag = 1}
         Comments = 'hey'
-        DependsOn = @("item1","item2")
-        SKU = @{name="Standard_LRS"}
+        DependsOn = @("item1", "item2")
+        SKU = @{name = "Standard_LRS"}
         Kind = 'storage'
-        Properties = @{prop1=1}
+        Properties = @{prop1 = 1}
         Type = 'Microsoft.Compute/virtualMachines'
     }
 

--- a/Tests/ConvertTo-Hash.Tests.ps1
+++ b/Tests/ConvertTo-Hash.Tests.ps1
@@ -97,8 +97,7 @@ Describe "ConvertTo-Hash" {
     Context "Array handling with pipeline" {
         
         $array = @()
-        foreach ($int in (1..2))
-        {
+        foreach ($int in (1..2)) {
             $array += [PSCustomObject]@{
                 Number = $int
                 Name = "My name is $int"
@@ -115,13 +114,12 @@ Describe "ConvertTo-Hash" {
             $arrayObj.ArrayItem -is [array] | Should be $true
         }
 
-        it "Should convert the array to a collection of OrderedDictionary"{
+        it "Should convert the array to a collection of OrderedDictionary" {
             $assert.GetType().Name | Should be "OrderedDictionary"
         }
 
         $index = 0
-        foreach ($hashItem in $assert.ArrayItem)
-        {
+        foreach ($hashItem in $assert.ArrayItem) {
             It "Should have a collection of OrderedDictionary values" {
                 $hashItem.GetType().Name | Should Be "OrderedDictionary"
             }
@@ -136,8 +134,7 @@ Describe "ConvertTo-Hash" {
     Context "Array handling without pipeline" {
         
         $array = @()
-        foreach ($int in (1..2))
-        {
+        foreach ($int in (1..2)) {
             $array += [PSCustomObject]@{
                 Number = $int
                 Name = "My name is $int"
@@ -154,13 +151,12 @@ Describe "ConvertTo-Hash" {
             $arrayObj.ArrayItem -is [array] | Should be $true
         }
 
-        it "Should convert the array to a collection of OrderedDictionary"{
+        it "Should convert the array to a collection of OrderedDictionary" {
             $assert.GetType().Name | Should be "OrderedDictionary"
         }
 
         $index = 0
-        foreach ($hashItem in $assert.ArrayItem)
-        {
+        foreach ($hashItem in $assert.ArrayItem) {
             It "Should have a collection of OrderedDictionary values" {
                 $hashItem.GetType().Name | Should Be "OrderedDictionary"
             }
@@ -173,7 +169,7 @@ Describe "ConvertTo-Hash" {
     }
 
     Context "Passthrou Hashtable with pipeline" {
-        $hash = @{test=1}
+        $hash = @{test = 1}
         $assert = $hash | ConvertTo-Hash
         It "Should Passthrou inputobject if it is a hashtable" {            
             $assert.GetType().Name | Should be "hashtable"
@@ -185,7 +181,7 @@ Describe "ConvertTo-Hash" {
     }
 
     Context "Passthrou OrderedDictionary with pipeline" {
-        $ordered = [ordered]@{test=1}
+        $ordered = [ordered]@{test = 1}
         $assert = $ordered | ConvertTo-Hash
 
         It "Should Passthrou inputobject if it is a OrderedDictionary" {            
@@ -198,7 +194,7 @@ Describe "ConvertTo-Hash" {
     }
 
     Context "Passthrou Hashtable without pipeline" {
-        $hash = @{test=1}
+        $hash = @{test = 1}
         $assert = ConvertTo-Hash -InputObject $hash
 
         It "Should Passthrou inputobject if it is a hashtable" {            
@@ -211,7 +207,7 @@ Describe "ConvertTo-Hash" {
     }
 
     Context "Passthrou OrderedDictionary without pipeline" {
-        $ordered = [ordered]@{test=1}
+        $ordered = [ordered]@{test = 1}
         $assert = ConvertTo-Hash -InputObject $ordered
 
         It "Should Passthrou inputobject if it is a OrderedDictionary" {            

--- a/Tests/Get-ARMparameterScript.Tests.ps1
+++ b/Tests/Get-ARMparameterScript.Tests.ps1
@@ -16,12 +16,10 @@ Describe "Get-ARMparameterScript" {
             Type = 'string'
         }
 
-        $actualParameter = New-ARMparameter @ExpectedParm | Add-ARMparameter
-
         $paramScript = Get-ARMtemplate | Select-Object -ExpandProperty parameters | Get-ARMparameterScript
         $scriptBlock = [scriptblock]::Create($paramScript)
 
-        New-ARMTemplate        
+        New-ARMTemplate
 
         It "Parameters should be empty before script invoke" {
             ((Get-ARMtemplate).parameters.psobject.properties | Measure-Object).Count | Should be 0

--- a/Tests/Get-ARMtemplateScript.Tests.ps1
+++ b/Tests/Get-ARMtemplateScript.Tests.ps1
@@ -25,7 +25,7 @@ Describe "Get-ARMtemplateScript" {
         }
 
         It "Invoking the script should create a new variable" {
-             ((Get-ARMtemplate).variables.psobject.properties | Measure-Object).Count | Should be 1
+            ((Get-ARMtemplate).variables.psobject.properties | Measure-Object).Count | Should be 1
         }
     }
 }

--- a/Tests/New-ARMparameter.Tests.ps1
+++ b/Tests/New-ARMparameter.Tests.ps1
@@ -12,13 +12,13 @@ Describe "New-ARMparameter" {
         Name = 'Resource'
         Type = 'string'
         DefaultValue = 'meh'
-        AllowedValues = @("meh", "det","foo")
+        AllowedValues = @("meh", "det", "foo")
         MinValue = 1
         MaxValue = 3
         MinLength = '3'
         MaxLength = '99'
         Description = 'Description'
-        Metadata = @{Comment="yalla"}
+        Metadata = @{Comment = "yalla"}
     }
 
     $actualParameter = New-ARMparameter @ExpectedParm

--- a/Tests/New-ARMresource.Tests.ps1
+++ b/Tests/New-ARMresource.Tests.ps1
@@ -12,12 +12,12 @@ Describe "New-ARMresource" {
         APIversion = '2016-03-30'
         Name = 'MyVM'
         Location = 'EAST-US'
-        Tags = @{tag=1}
+        Tags = @{tag = 1}
         Comments = 'hey'
-        DependsOn = @("item1","item2")
+        DependsOn = @("item1", "item2")
         SKU = @{value = "skuvalue"}
         Kind = 'storage'
-        Properties = @{prop1=1}
+        Properties = @{prop1 = 1}
         Type = 'Microsoft.Compute/virtualMachines'
     }
 
@@ -33,7 +33,7 @@ Describe "New-ARMresource" {
             $Actual.GetType().Name | Should be "PSCustomObject"
         }
 
-         It "Should create a PSCustomObject with PStypeName 'ARMresource'" {
+        It "Should create a PSCustomObject with PStypeName 'ARMresource'" {
             $Actual.pstypenames[0] | should be "ARMresource"
         }
 

--- a/Tests/New-ArmTemplate.Tests.ps1
+++ b/Tests/New-ArmTemplate.Tests.ps1
@@ -22,19 +22,19 @@ Describe "New-ARMTemplate" {
         }
 
         It "Should have a [parameters] property of type [PScustomobject]" {
-             (Get-ARMTemplate).parameters.GetType().Name | Should be 'PScustomobject'
+            (Get-ARMTemplate).parameters.GetType().Name | Should be 'PScustomobject'
         }
 
         It "Should have a [variables] property of type [PScustomobject]" {
-             (Get-ARMTemplate).variables.GetType().Name | Should be 'PScustomobject'
+            (Get-ARMTemplate).variables.GetType().Name | Should be 'PScustomobject'
         }
 
         It "Should have a [resources] property of type Object[]" {
-             (Get-ARMTemplate).resources.GetType().Name | Should be 'Object[]'
+            (Get-ARMTemplate).resources.GetType().Name | Should be 'Object[]'
         }
 
         It "Should have a [outputs] property of type [PScustomobject]" {
-             (Get-ARMTemplate).outputs.GetType().Name | Should be 'PScustomobject'
+            (Get-ARMTemplate).outputs.GetType().Name | Should be 'PScustomobject'
         }
 
         It "Should return an object if Passthru is specified" {

--- a/Tests/Out-HashString.Tests.ps1
+++ b/Tests/Out-HashString.Tests.ps1
@@ -16,14 +16,14 @@ Describe "Out-HashString" {
         }
 
         It "Should convert a hashtabel to a string representation" {
-            $var = @{Test="keyValue"}
+            $var = @{Test = "keyValue"}
             $Expected = '@{\r\n    Test = "keyValue"\r\n}' -replace ([regex]::Escape("\r\n")), [environment]::NewLine
             $actual = Out-HashString -InputObject $var
             $actual | Should Be $Expected
         }
 
         It "Should handle nested hashtables" {
-            $var = @{Test="keyValue";Nested = @{Key1="Value1";Key2="Value2"}}
+            $var = @{Test = "keyValue"; Nested = @{Key1 = "Value1"; Key2 = "Value2"}}
             $Expected = '@{\r\n    Test = "keyValue"\r\n    Nested = @{\r\n        Key1 = "Value1"\r\n        Key2 = "Value2"\r\n    }\r\n}' -replace ([regex]::Escape("\r\n")), [environment]::NewLine
             $actual = Out-HashString -InputObject $var
             $actual | Should Be $Expected
@@ -38,14 +38,14 @@ Describe "Out-HashString" {
         }
 
         It "Should convert a hashtabel to a string representation" {
-            $var = @{Test="keyValue"}
+            $var = @{Test = "keyValue"}
             $Expected = '@{\r\n    Test = "keyValue"\r\n}' -replace ([regex]::Escape("\r\n")), [environment]::NewLine
             $actual = $var | Out-HashString
             $actual | Should Be $Expected
         }
 
         It "Should handle nested hashtables" {
-            $var = @{Test="keyValue";Nested = @{Key1="Value1";Key2="Value2"}}
+            $var = @{Test = "keyValue"; Nested = @{Key1 = "Value1"; Key2 = "Value2"}}
             $Expected = '@{\r\n    Test = "keyValue"\r\n    Nested = @{\r\n        Key1 = "Value1"\r\n        Key2 = "Value2"\r\n    }\r\n}' -replace ([regex]::Escape("\r\n")), [environment]::NewLine
             $actual = $var | Out-HashString
             $actual | Should Be $Expected

--- a/Tests/Set-ARMparameter.Tests.ps1
+++ b/Tests/Set-ARMparameter.Tests.ps1
@@ -8,8 +8,6 @@ Import-Module $modulePath
 
 New-ArmTemplate
 
-$newParam = New-ARMparameter -Name test -Type string | Add-ARMparameter -PassThru
-
 $newParameterValue = @{
     Type = "int"
     DefaultValue = "test"

--- a/Tests/Set-ARMvariable.Tests.ps1
+++ b/Tests/Set-ARMvariable.Tests.ps1
@@ -8,8 +8,6 @@ Import-Module $modulePath
 
 New-ArmTemplate
 
-$newVar = New-ARMvariable -Name test -Value testvalue | Add-ARMvariable -PassThru
-
 $newVariableValue = @{
     Name = "test"
     Value = "newTestValue"

--- a/publish.ps1
+++ b/publish.ps1
@@ -5,23 +5,4 @@ Param(
     $APIkey
 )
 
-$tags = @(
-    "Azure"
-    , 
-    "Template"
-    , 
-    "ARM"
-    , 
-    "JSON"
-    , 
-    "Resource"
-    ,
-    "Manager"
-    ,
-    "Convert"
-    ,
-    "Import"
-)
-
-
 Publish-Module -NuGetApiKey $APIkey -Name .\posharm.psd1


### PR DESCRIPTION
I took the liberty to add PSScriptAnalyzer with a settings file which includes basically all the rules.  I fixed all the violations that were flagged with the analyzer.

To invoke it, run `Invoke-ScriptAnalyzer -Path .\ -Recurse` from the root folder of the module.

FYI, I use VSCode to quickly format the PowerShell files.  ISE uses 2 spaces as a tab which is pretty aweful.

Also, may I suggest renaming the files and functions to PascalCase?  i.e. Add-ArmParameter, New-ArmTemplate, etc.

Cheers,

Yohan